### PR TITLE
fix bug #24873 - nested prefetch bug

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1892,7 +1892,12 @@ def prefetch_one_level(instances, prefetcher, lookup, level):
     # contains some prefetch_related lookups. We don't want to trigger the
     # prefetch_related functionality by evaluating the query. Rather, we need
     # to merge in the prefetch_related lookups.
-    additional_lookups = getattr(rel_qs, '_prefetch_related_lookups', [])
+    # We need to copy the lookups in case it is a Prefetch object which could
+    # be reused later, which happens in nested prefetch_related.
+    additional_lookups = [
+        copy.copy(additional_lookup) for additional_lookup
+        in getattr(rel_qs, '_prefetch_related_lookups', [])
+    ]
     if additional_lookups:
         # Don't need to clone because the manager should have given us a fresh
         # instance, so we access an internal instead of using public interface

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -624,6 +624,20 @@ class CustomPrefetchTests(TestCase):
         room = Room.objects.filter(main_room_of__isnull=False).prefetch_related(Prefetch('main_room_of', queryset=houses.filter(address='DoesNotExist'), to_attr='main_room_of_attr')).first()
         self.assertIsNone(room.main_room_of_attr)
 
+    def test_nested_prefetch_related_are_not_overwritten(self):
+        # Regression test for #24873
+        houses_2 = House.objects.prefetch_related(Prefetch('rooms'))
+        persons = Person.objects.prefetch_related(Prefetch('houses', queryset=houses_2))
+        houses = House.objects.prefetch_related(Prefetch('occupants', queryset=persons))
+        # It seems like the queryset must be evaluated once to overwrite the Prefetch objects
+        # to cause the bug when there are ManyToManyFields.
+        list(houses)
+        # Access the nested objects now. It will break if Prefetch objects are overwritten.
+        self.assertEqual(
+            houses.all()[0].occupants.all()[0].houses.all()[1].rooms.all()[0],
+            self.room2_1
+        )
+
 
 class DefaultManagerTests(TestCase):
 


### PR DESCRIPTION
@aleontiev - This is a straight up port of [the proposed fix](https://github.com/django/django/pull/4723) to the [prefetch bug](https://code.djangoproject.com/ticket/24873) applied to the latest stable 1.7.x branch. Confirmed all tests pass locally.
